### PR TITLE
 Executing middleware before the async

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -10,7 +10,7 @@ let store = null;
 
 export default (middlewareList) => {
   if (!store) {
-    const ml = [asyncMiddleware].concat(middlewareList);
+    const ml = middlewareList.concat([asyncMiddleware]);
 
     const enchance = applyMiddleware(...ml);
 


### PR DESCRIPTION
中间件执行顺序应在异步函数之前，现在顺序是反的