### PR TITLE
V2.x

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -17,3 +17,12 @@
 
 ## v2.4.0
 * Model实例提供getState方法，以供扩展使用
+
+
+## v2.5.0
+* namespace多实例自动生成存在严重bug，该功能放弃，多实例请通过props.namespace的方式自行传入支持
+
+
+
+## v2.6.0
+* 提供kos.WrapperProvider高阶方法，返回Provider包裹的高阶组件

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -26,3 +26,8 @@
 
 ## v2.6.0
 * 提供kos.WrapperProvider高阶方法，返回Provider包裹的高阶组件
+
+
+
+## v2.7.0
+* 提供redux-dev-tools支持

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -16,21 +16,24 @@
 * namespace支持多实例能力
 
 ## v2.4.0
-* Model实例提供getState方法，以供扩展使用
+* feat: Model实例提供getState方法，以供扩展使用
 
 
 ## v2.5.0
-* namespace多实例自动生成存在严重bug，该功能放弃，多实例请通过props.namespace的方式自行传入支持
+* bugfix: namespace多实例自动生成存在严重bug，该功能放弃，多实例请通过props.namespace的方式自行传入支持
 
 
 
 ## v2.6.0
-* 提供kos.WrapperProvider高阶方法，返回Provider包裹的高阶组件
+* feat: 提供kos.WrapperProvider高阶方法，返回Provider包裹的高阶组件
 
 
 
 ## v2.7.0
-* 提供redux-dev-tools支持
+* feat: 提供redux-dev-tools支持
 
 ## v2.7.1
-* 提供redux-dev-tools支持
+* bigfix: 解决redux-devtools-extension的依赖bug
+
+## v2.7.2
+* bugfix: 兼容未安装redux-devtools-extension的情况

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -31,3 +31,6 @@
 
 ## v2.7.0
 * 提供redux-dev-tools支持
+
+## v2.7.1
+* 提供redux-dev-tools支持

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,3 +9,8 @@
 
 ## v2.0.0
 * 修复middleware顺序错误，v1.x的时候，kos.use的middleware执行顺序为先use，后执行；v2.x以后修改为先use先执行
+
+
+## v2.3.0
+* 提供namespace自动生成能力
+* namespace支持多实例能力

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -14,3 +14,6 @@
 ## v2.3.0
 * 提供namespace自动生成能力
 * namespace支持多实例能力
+
+## v2.4.0
+* Model实例提供getState方法，以供扩展使用

--- a/index.js
+++ b/index.js
@@ -8,7 +8,10 @@ import Model from "./src/model";
 
 import Store from "./src/store";
 
+// 全局的中间件
 const middlewareList = [];
+
+// 全局的Wrapper扩展属性
 const wrapperProps = {};
 
 const KOS = {
@@ -26,9 +29,14 @@ const KOS = {
   wrapperProps: props => {
     Object.assign(wrapperProps, props);
   },
-  Wrapper: Wrapper(wrapperProps),
+  Wrapper: Wrapper()(wrapperProps),
+  WrapperProvider: config => {
+    const store = Store(middlewareList);
+    return Wrapper(store)(wrapperProps)(config);
+  },
   Provider(Layout) {
-    Store(middlewareList);
+    const store = Store(middlewareList);
+
     return (
       <Provider store={store}>
         <Layout />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kos-core",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "基于react-redux的可使用封装",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kos-core",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "基于react-redux的可使用封装",
   "repository": {
     "type": "git",
@@ -38,6 +38,7 @@
     "eslint-plugin-jsx-a11y": "^6.0.3",
     "eslint-plugin-react": "^7.7.0",
     "rollup": "^0.57.1",
-    "rollup-plugin-babel": "^3.0.3"
+    "rollup-plugin-babel": "^3.0.3",
+    "redux-devtools-extension'": "2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kos-core",
-  "version": "2.4.0",
+  "version": "2.6.0",
   "description": "基于react-redux的可使用封装",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kos-core",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "基于react-redux的可使用封装",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kos-core",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "description": "基于react-redux的可使用封装",
   "repository": {
     "type": "git",
@@ -39,6 +39,6 @@
     "eslint-plugin-react": "^7.7.0",
     "rollup": "^0.57.1",
     "rollup-plugin-babel": "^3.0.3",
-    "redux-devtools-extension'": "2"
+    "redux-devtools-extension": "2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kos-core",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "基于react-redux的可使用封装",
   "repository": {
     "type": "git",

--- a/src/model.js
+++ b/src/model.js
@@ -1,3 +1,4 @@
+import Store from "./store";
 
 const DefaultReducers = {
   setState(state, action) {
@@ -10,31 +11,29 @@ const DefaultReducers = {
 
     return {
       ...state,
-      ...payload,
+      ...payload
     };
   },
   reset(state, action) {
     return {
-      ...action.payload,
+      ...action.payload
     };
-  },
+  }
 };
 
 const Model = class {
   constructor(model) {
-    const {
-      namespace, asyncs, reducers, setup,
-    } = model;
+    const { namespace, asyncs, reducers, setup } = model;
     this.namespace = namespace;
     Object.assign(model, {
       asyncs: {
         setup,
-        ...asyncs,
+        ...asyncs
       },
       reducers: {
         ...DefaultReducers,
-        ...reducers,
-      },
+        ...reducers
+      }
     });
 
     this.model = model;
@@ -54,17 +53,22 @@ const Model = class {
   getAttr(attrName) {
     return this.model[attrName];
   }
+  getState() {
+    const namespace = this.getNamespace();
+    const state = Store().getState() || {};
+    return state[namespace];
+  }
   getSetup() {
     return this.model.setup;
   }
 };
 
-const createModelFactory = (model) => {
+const createModelFactory = model => {
   const { namespace } = model;
 
   if (!namespace) {
-    console.error('namespace is undefined!', model);  // eslint-disable-line
-    throw new Error('namespace is undefined!');
+    console.error("namespace is undefined!", model); // eslint-disable-line
+    throw new Error("namespace is undefined!");
   }
   return new Model(model); // eslint-disable-line
 };
@@ -96,7 +100,8 @@ Object.assign(Model, {
     return initial;
   },
   each(callback) {
-    for (const namespace in map) { // eslint-disable-line
+    for (const namespace in map) {
+      // eslint-disable-line
       callback(namespace, map[namespace]);
     }
   },
@@ -112,7 +117,7 @@ Object.assign(Model, {
     const model = this.get(namespace);
 
     return model && model.setup;
-  },
+  }
 });
 
 export default Model;

--- a/src/store.js
+++ b/src/store.js
@@ -4,6 +4,7 @@ import asyncMiddleware from './async-middleware';
 import RootReducer from './root-reducer';
 import { createStore, applyMiddleware } from 'redux';
 
+const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 
 
 let store = null;
@@ -17,7 +18,7 @@ export default (middlewareList) => {
     const initial = Model.getInitial();
     const rootReducer = RootReducer(Model);
 
-    window.store = store = createStore(rootReducer, initial, enchance); // eslint-disable-line
+    window.store = store = createStore(rootReducer, initial, composeEnhancers(enchance)); // eslint-disable-line
   }
 
   return store

--- a/src/store.js
+++ b/src/store.js
@@ -1,15 +1,13 @@
-
-import Model from './model';
-import asyncMiddleware from './async-middleware';
-import RootReducer from './root-reducer';
-import { createStore, applyMiddleware } from 'redux';
+import Model from "./model";
+import asyncMiddleware from "./async-middleware";
+import RootReducer from "./root-reducer";
+import { createStore, applyMiddleware, compose } from "redux";
 
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 
-
 let store = null;
 
-export default (middlewareList) => {
+export default middlewareList => {
   if (!store) {
     const ml = [...middlewareList, asyncMiddleware];
 
@@ -18,8 +16,12 @@ export default (middlewareList) => {
     const initial = Model.getInitial();
     const rootReducer = RootReducer(Model);
 
-    window.store = store = createStore(rootReducer, initial, composeEnhancers(enchance)); // eslint-disable-line
+    window.store = store = createStore(
+      rootReducer,
+      initial,
+      composeEnhancers(enchance)
+    ); // eslint-disable-line
   }
 
-  return store
+  return store;
 };

--- a/src/wrapper.js
+++ b/src/wrapper.js
@@ -30,7 +30,6 @@ const Wrapper = config => Component => {
       });
 
       this.dispatch = wrapperDispatch(props.dispatch, this.namespace);
-
     }
     getChildContext() {
       return {
@@ -125,27 +124,40 @@ const Wrapper = config => Component => {
   return WrapperComponent;
 };
 
+const NamespaceMap = {};
 export default WrapperProps => config => Component => {
-  const { model } = config;
-  config.namespace = config.namespace || model.namespace;
+  // const { model } = config;
+  // config.namespace = config.namespace || model.namespace;
 
-  config.namespace &&
-    Model.add({
-      ...model,
-      namespace: config.namespace
-    });
+  // config.namespace &&
+  //   Model.add({
+  //     ...model,
+  //     namespace: config.namespace
+  //   });
 
   return class WrapperConnect extends React.PureComponent {
     constructor(props) {
       super(props);
+      const { model } = config;
 
-      const namespace = props.namespace || config.namespace || model.namespace;
-      if (namespace && namespace !== config.namespace) {
-        Model.add({
-          ...model,
-          namespace
-        });
+      let namespace =
+        props.namespace ||
+        config.namespace ||
+        model.namespace ||
+        Component.name;
+
+      // 没有被注册过
+      NamespaceMap[namespace] = NamespaceMap[namespace] || 0;
+      const insCount = NamespaceMap[namespace];
+      NamespaceMap[namespace]++;
+      if (insCount) {
+        namespace = `${namespace}-${insCount}`;
       }
+
+      Model.add({
+        ...model,
+        namespace
+      });
 
       const WrapperComponent = Wrapper({
         ...config,

--- a/src/wrapper.js
+++ b/src/wrapper.js
@@ -128,15 +128,6 @@ const Wrapper = config => Component => {
 
 const NamespaceMap = {};
 export default WrapperProps => config => Component => {
-  // const { model } = config;
-  // config.namespace = config.namespace || model.namespace;
-
-  // config.namespace &&
-  //   Model.add({
-  //     ...model,
-  //     namespace: config.namespace
-  //   });
-
   return class WrapperConnect extends React.PureComponent {
     constructor(props) {
       super(props);


### PR DESCRIPTION
If the query string of page is not the standard format, the page will crash when decode the param. but sometimes, we will have to pass the unformatted query string as media and pass it to the serverside. So we need to catch the error to avoid the page crash.