### PR TITLE
Fix page crash when decode query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ yarn*
 **/frame/index.js
 node_modules/
 lib/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ interface Util {
     getParam: () => any;
 }
 ```
-
+##### 2
 ```
     setup?: (dispatch: KosDispatch, getState: GetKosState<T>) => void;
 ```

--- a/README.md
+++ b/README.md
@@ -109,6 +109,27 @@ export default {
 #### Definition(@types/kos-core) change log
 ``` install: npm install @types/kos-core ```
 
+2019-4-8: Update asyncs function's paramaters as unrequited to fit much more scenarios
+change
+```
+export interface KosModel<T = any> {
+    ...;
+    asyncs: {
+        [key: string]: (dispatch: KosDispatch, getState: GetKosState<T>, action: Action) => void;
+    };
+    ...
+```
+to
+```
+export interface KosModel<T = any> {
+    ...;
+    asyncs: {
+        [key: string]: (dispatch?: KosDispatch, getState?: GetKosState<T>, action?: { payload: T }) => void;
+    };
+    ...
+```
+
+
 2018-11-1:
 change
 ```

--- a/README.md
+++ b/README.md
@@ -142,6 +142,30 @@ export default {
 #### Definition(@types/kos-core) change log
 ``` install: npm install @types/kos-core ```
 
+2019-5-22: Update definitions to fit new version.
+
+##### 1
+```
+interface Util {
+    getActionType: (action: string) => { namespace: string | null; type: string };
+}
+```
+to
+```
+interface Util {
+    getActionType: (action: string) => { namespace: string | null; type: string };
+    getParam: () => any;
+}
+```
+
+```
+    setup?: (dispatch: KosDispatch, getState: GetKosState<T>) => void;
+```
+to
+```
+    setup?: (dispatch: KosDispatch, getState: GetKosState<T>, action: { payload: { param: any } }) => void;
+```
+
 2019-4-8: Update asyncs function's paramaters as unrequited to fit much more scenarios.
 ```
 export interface KosModel<T = any> {

--- a/README.md
+++ b/README.md
@@ -109,8 +109,7 @@ export default {
 #### Definition(@types/kos-core) change log
 ``` install: npm install @types/kos-core ```
 
-2019-4-8: Update asyncs function's paramaters as unrequited to fit much more scenarios
-change
+2019-4-8: Update asyncs function's paramaters as unrequited to fit much more scenarios.
 ```
 export interface KosModel<T = any> {
     ...;

--- a/README.md
+++ b/README.md
@@ -106,6 +106,26 @@ export default {
 
 #### API说明
 
+#### Definition(@types/kos-core) change log
+``` install: npm install @types/kos-core ```
 
-
+2018-11-1:
+change
+```
+export interface KosModel<T = any> {
+    ...;
+    asyncs: {
+        [key: string]: (dispatch: KosDispatch, getState?: GetKosState<T>) => void;
+    };
+    ...
+```
+to
+```
+export interface KosModel<T = any> {
+    ...;
+    asyncs: {
+        [key: string]: (dispatch: KosDispatch, getState: GetKosState<T>, action: Action) => void;
+    };
+    ...
+```
 

--- a/src/store.js
+++ b/src/store.js
@@ -2,7 +2,7 @@
 import Model from './model';
 import asyncMiddleware from './async-middleware';
 import RootReducer from './root-reducer';
-import { createStore, applyMiddleware } from 'redux';
+import { createStore, applyMiddleware, compose } from 'redux';
 
 
 
@@ -17,7 +17,12 @@ export default (middlewareList) => {
     const initial = Model.getInitial();
     const rootReducer = RootReducer(Model);
 
-    window.store = store = createStore(rootReducer, initial, enchance); // eslint-disable-line
+    if (!window.__REDUX_DEVTOOLS_EXTENSION__) {
+      window.store = store = createStore(rootReducer, initial, enchance); // eslint-disable-line
+    } else {
+      window.store = store = createStore(rootReducer, initial, // eslint-disable-line
+        compose(enchance, window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__())); // eslint-disable-line
+    }
   }
 
   return store

--- a/src/util.js
+++ b/src/util.js
@@ -30,8 +30,12 @@ export function getParam() {
   }
   search.forEach((equation) => {
     const [key, value] = equation.split('=');
-    if (value !== undefined) {
-      query[decodeURIComponent(key)] = decodeURIComponent(value);
+    try {
+      if (value !== undefined) {
+        query[decodeURIComponent(key)] = decodeURIComponent(value);
+      }
+    } catch (error) {
+      console.error(error.message || `Error happened when decodeURIComponent ${value}`)
     }
   });
   return query;


### PR DESCRIPTION
If the query string of page is not standard, the page will crash when decoding the query string of window.location.href. But in some cases, we have to pass the unformatted query strings as media and pass it to the server-side. so we need to catch the error to avoid the page crash.