### PR TITLE
fix: page crash when decode uri

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -30,8 +30,12 @@ export function getParam() {
   }
   search.forEach((equation) => {
     const [key, value] = equation.split('=');
-    if (value !== undefined) {
-      query[decodeURIComponent(key)] = decodeURIComponent(value);
+    try {
+      if (value !== undefined) {
+        query[decodeURIComponent(key)] = decodeURIComponent(value);
+      }
+    } catch (error) {
+      console.error(error.message || `Error happened when decodeURIComponent ${value}`)
     }
   });
   return query;


### PR DESCRIPTION
If the query string of page is not standard, the page will crash when decoding the query string of window.location.href. But in some cases, we have to pass the unformatted query strings as media and pass it to the server-side. so we need to catch the error to avoid the page crash.